### PR TITLE
fix build with javadoc in java 8

### DIFF
--- a/kinetic-client/pom.xml
+++ b/kinetic-client/pom.xml
@@ -131,7 +131,7 @@
 		<profile>
 			<id>doclint-java8-disable</id>
 			<activation>
-				<jdk>[1.8,</jdk>
+				<jdk>[1.8,)</jdk>
 			</activation>
 			<properties>
 				<additionalparam>-Xdoclint:none</additionalparam>

--- a/kinetic-common/pom.xml
+++ b/kinetic-common/pom.xml
@@ -159,7 +159,7 @@
 		<profile>
 			<id>doclint-java8-disable</id>
 			<activation>
-				<jdk>[1.8,</jdk>
+				<jdk>[1.8,)</jdk>
 			</activation>
 			<properties>
 				<additionalparam>-Xdoclint:none</additionalparam>

--- a/kinetic-simulator/pom.xml
+++ b/kinetic-simulator/pom.xml
@@ -141,7 +141,7 @@
 		<profile>
 			<id>doclint-java8-disable</id>
 			<activation>
-				<jdk>[1.8,</jdk>
+				<jdk>[1.8,)</jdk>
 			</activation>
 			<properties>
 				<additionalparam>-Xdoclint:none</additionalparam>

--- a/kinetic-test/pom.xml
+++ b/kinetic-test/pom.xml
@@ -128,7 +128,7 @@
 		<profile>
 			<id>doclint-java8-disable</id>
 			<activation>
-				<jdk>[1.8,</jdk>
+				<jdk>[1.8,)</jdk>
 			</activation>
 			<properties>
 				<additionalparam>-Xdoclint:none</additionalparam>


### PR DESCRIPTION
Hi

I had some troubles building the simulator on my machine (latest ubuntu with latest openjdk).
This patch fixes one of the problems I encountered.

Fwiw, I had another problem with https://github.com/domsj/kinetic-java/blob/1a6eb187aa18cdb3187c0e48d6b0335e5fbb09b4/kinetic-common/pom.xml#L58 in which the ${project.parent.basedir} somehow resulted in null, but I don't know what the appropriate fix there should be. I just hardcoded the needed path in there.

Kind regards,
Jan