### PR TITLE
RestHeartbeatService: Add a command line argument to give the name of…

### DIFF
--- a/kinetic-test/src/test/java/com/seagate/kinetic/example/heartbeat/rest/HeartbeatCollector.java
+++ b/kinetic-test/src/test/java/com/seagate/kinetic/example/heartbeat/rest/HeartbeatCollector.java
@@ -60,6 +60,10 @@ public class HeartbeatCollector extends HeartbeatListener {
     public HeartbeatCollector() throws IOException {
         super();
     }
+
+    public HeartbeatCollector(String netInterfaceName) throws IOException {
+        super(netInterfaceName);
+    }
     
     @Override
     public void onMessage(byte[] data) {

--- a/kinetic-test/src/test/java/com/seagate/kinetic/example/heartbeat/rest/RestHeartbeatService.java
+++ b/kinetic-test/src/test/java/com/seagate/kinetic/example/heartbeat/rest/RestHeartbeatService.java
@@ -52,8 +52,15 @@ public class RestHeartbeatService {
         if (args.length >0) {
             port = Integer.parseInt(args[0]);
         }
+
+        HeartbeatCollector hbc = null;
+
+        if (args.length > 1) {
+            hbc = new HeartbeatCollector(args[1]);
+        } else {
+            hbc = new HeartbeatCollector();
+        }
         
-        HeartbeatCollector hbc = new HeartbeatCollector();
         HeartbeatHandler handler = new HeartbeatHandler (hbc);
         
         Server server = new Server(port);


### PR DESCRIPTION
… the interface to use

When several interfaces are available on the host we need to specify to the tool the one it must use.